### PR TITLE
Add Infernal Strike to spell list and rotation

### DIFF
--- a/Specialization/Vengeance.lua
+++ b/Specialization/Vengeance.lua
@@ -25,6 +25,7 @@ local VG = {
 	DemonSpikes        = 203720,
 	DemonSpikesAura    = 203819,
 	SoulBarrier        = 263648,
+	InfernalStrike	   = 189110,
 };
 
 setmetatable(VG, DemonHunter.spellMeta);
@@ -40,6 +41,7 @@ function DemonHunter:Vengeance()
 
 	MaxDps:GlowCooldown(VG.Metamorphosis, cooldown[VG.Metamorphosis].ready);
 	MaxDps:GlowCooldown(VG.DemonSpikes, cooldown[VG.DemonSpikes].ready and not buff[VG.DemonSpikesAura].up);
+	MaxDps:GlowCooldown(VG.FieryBrand, cooldown[VG.FieryBrand].ready);
 
 	if talents[VG.SoulBarrier] then
 		MaxDps:GlowCooldown(VG.SoulBarrier, cooldown[VG.SoulBarrier].ready);
@@ -51,6 +53,11 @@ function DemonHunter:Vengeance()
 	end
 
 	--- SIMC
+	-- infernal_strike;
+	if cooldown[VG.InfernalStrike].ready then
+		return VG.InfernalStrike;
+	end
+
 	-- spirit_bomb,if=soul_fragments>=4;
 	if talents[VG.SpiritBomb] and pain >= 30 and soulFragments >= 4 then
 		return VG.SpiritBomb;
@@ -115,6 +122,11 @@ function DemonHunter:VengeanceBrand()
 	-- sigil_of_flame,if=cooldown.fiery_brand.remains<2;
 	if cooldown[VG.FieryBrand].remains < 2 and cooldown[VG.SigilOfFlame].ready then
 		return VG.SigilOfFlame;
+	end
+
+	-- infernal_stike,if=cooldown.fiery_brand.remains=0;
+	if cooldown[VG.FieryBrand].remains < 2 and cooldown[VG.InfernalStrike].ready then
+		return VG.InfernalStrike;
 	end
 
 	-- fiery_brand;


### PR DESCRIPTION
A few fixes:
 - Infernal Strike was missing from Spell List and Rotations
 - Fiery Brand is considered a "defensive" under simc, and is used as top priority for damage.

I tested both a normal and brand rotation with these UI changes at a target dummy.

https://github.com/simulationcraft/simc/blob/04ddfb92f023d082a1919a16b282d4c51c4fdb06/engine/class_modules/sc_demon_hunter.cpp#L5229